### PR TITLE
Fixes for Visual Studio 2015 compatibility

### DIFF
--- a/TheKoans/AboutArrays.cs
+++ b/TheKoans/AboutArrays.cs
@@ -27,7 +27,7 @@ namespace TheKoans
         {
             var array = new[] { 42 };
             Assert.AreEqual(typeof(int[]), array.GetType(), "You don't have to specify a type if the elements can be inferred");
-            Assert.AreEqual(new int[] { 42 }, array, "These arrays are literally equal... But you won't see this string in the error message.");
+            CollectionAssert.AreEqual(new int[] { 42 }, array, "These arrays are literally equal... But you won't see this string in the error message.");
 
             //Are arrays 0-based or 1-based?
             Assert.AreEqual(42, array[((int)FILL_ME_IN)], "Well, it's either 0 or 1.. you have a 110010-110010 chance of getting it right.");
@@ -108,7 +108,7 @@ namespace TheKoans
             var array = new[] { "peanut", "butter", "and", "jelly" };
 
             // Calling an array's Take(x) method will return the specified x number of elements from the start of the array.
-            Assert.AreEqual(new string[] { "peanut", "butter" }, array.Take((int) FILL_ME_IN).ToArray(), "George Washington Carver would be proud you've found another use of peanut butter.");
+            CollectionAssert.AreEqual(new string[] { "peanut", "butter" }, array.Take((int) FILL_ME_IN).ToArray(), "George Washington Carver would be proud you've found another use of peanut butter.");
             // Calling an array's Skip(y) method will bypass the specified y number of elements from the start of the array and return the remaining elements.
             CollectionAssert.AreEqual(new string[] { "and" }, array.Skip((int)FILL_ME_IN).Take(1).ToArray(), "Your array slicing skills need more practice to hone your C# Karma.");
         }

--- a/TheKoans/AboutHashes.cs
+++ b/TheKoans/AboutHashes.cs
@@ -12,8 +12,8 @@ namespace TheKoans
         public void CreatingHashes()
         {
             var hash = new Hashtable();
-            Assert.Equals(typeof(System.Collections.Hashtable), hash.GetType());
-            Assert.Equals(FILL_ME_IN, hash.Count);
+            Assert.AreEqual(typeof(System.Collections.Hashtable), hash.GetType());
+            Assert.AreEqual(FILL_ME_IN, hash.Count);
         }
 
         [TestMethod]
@@ -23,16 +23,16 @@ namespace TheKoans
             //See Haacked's blog here: http://haacked.com/archive/2008/01/06/collection-initializers.aspx
             //This is one way:
             var hash = new Hashtable() { { "one", "uno" }, { "two", "dos" } };
-            Assert.Equals(FILL_ME_IN, hash.Count);
+            Assert.AreEqual(FILL_ME_IN, hash.Count);
         }
 
         [TestMethod]
         public void AccessingHashes()
         {
             var hash = new Hashtable() { { "one", "uno" }, { "two", "dos" } };
-            Assert.Equals(FILL_ME_IN, hash["one"]);
-            Assert.Equals(FILL_ME_IN, hash["two"]);
-            Assert.Equals(FILL_ME_IN, hash["doesntExist"]);
+            Assert.AreEqual(FILL_ME_IN, hash["one"]);
+            Assert.AreEqual(FILL_ME_IN, hash["two"]);
+            Assert.AreEqual(FILL_ME_IN, hash["doesntExist"]);
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace TheKoans
             hash["one"] = "eins";
 
             var expected = new Hashtable() { { "one", FILL_ME_IN }, { "two", "dos" } };
-            Assert.Equals(expected, hash);
+            CollectionAssert.AreEqual(expected, hash);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace TheKoans
         {
             var hash1 = new Hashtable() { { "one", "uno" }, { "two", "dos" } };
             var hash2 = new Hashtable() { { "two", "dos" }, { "one", "uno" } };
-            Assert.Equals(hash1, hash2);
+            CollectionAssert.AreEqual(hash1, hash2);
         }
 
         [TestMethod]
@@ -69,14 +69,14 @@ namespace TheKoans
             var actualKeys = hash.Keys.Cast<string>().ToList();
             actualKeys.Sort();
 
-            Assert.Equals(expectedKeys, actualKeys);
+            CollectionAssert.AreEqual(expectedKeys, actualKeys);
 
             var expectedValues = new List<string>() { FILL_ME_IN.ToString(), FILL_ME_IN.ToString() };
             expectedValues.Sort();
             var actualValues = hash.Values.Cast<string>().ToList();
             actualValues.Sort();
 
-            Assert.Equals(expectedValues, actualValues);
+            CollectionAssert.AreEqual(expectedValues, actualValues);
         }
 
         //Begin RJG Took the original code out of CombiningHashes() method below
@@ -122,9 +122,9 @@ namespace TheKoans
                 hash[item.Key] = item.Value;
             }
 
-            Assert.Equals(FILL_ME_IN, hash["jim"]);
-            Assert.Equals(FILL_ME_IN, hash["jenny"]);
-            Assert.Equals(FILL_ME_IN, hash["amy"]);
+            Assert.AreEqual(FILL_ME_IN, hash["jim"]);
+            Assert.AreEqual(FILL_ME_IN, hash["jenny"]);
+            Assert.AreEqual(FILL_ME_IN, hash["amy"]);
 
         }
 

--- a/TheKoans/AboutInheritance.cs
+++ b/TheKoans/AboutInheritance.cs
@@ -72,14 +72,14 @@ namespace TheKoans
         public void SubclassesInheritBehaviorFromParentClass()
         {
             var chico = new Chihuahua("Chico");
-            Assert.Equals(FILL_ME_IN, chico.Name);
+            Assert.AreEqual(FILL_ME_IN, chico.Name);
         }
 
         [TestMethod]
         public void SubclassesAddNewBehavior()
         {
             var chico = new Chihuahua("Chico");
-            Assert.Equals(FILL_ME_IN, chico.Wag());
+            Assert.AreEqual(FILL_ME_IN, chico.Wag());
 
             //We can search the public methods of an object 
             //instance like this:
@@ -95,16 +95,16 @@ namespace TheKoans
         public void SubclassesCanModifyExistingBehavior()
         {
             var chico = new Chihuahua("Chico");
-            Assert.Equals(FILL_ME_IN, chico.Bark());
+            Assert.AreEqual(FILL_ME_IN, chico.Bark());
 
             //Note that even if we cast the object back to a dog
             //we still get the Chihuahua's behavior. It truly
             //"is-a" Chihuahua
             Dog dog = chico as Dog;
-            Assert.Equals(FILL_ME_IN, dog.Bark());
+            Assert.AreEqual(FILL_ME_IN, dog.Bark());
 
             var fido = new Dog("Fido");
-            Assert.Equals(FILL_ME_IN, fido.Bark());
+            Assert.AreEqual(FILL_ME_IN, fido.Bark());
         }
 
         public class ReallyYippyChihuahua : Chihuahua
@@ -126,7 +126,7 @@ namespace TheKoans
         public void SubclassesCanRedefineBehaviorThatIsNotVirtual()
         {
             ReallyYippyChihuahua suzie = new ReallyYippyChihuahua("Suzie");
-            Assert.Equals(FILL_ME_IN, suzie.Wag());
+            Assert.AreEqual(FILL_ME_IN, suzie.Wag());
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@ namespace TheKoans
             //method did what we defined in our class. But what happens
             //when we do this?
             Chihuahua bennie = new ReallyYippyChihuahua("Bennie");
-            Assert.Equals(FILL_ME_IN, bennie.Wag());
+            Assert.AreEqual(FILL_ME_IN, bennie.Wag());
 
             //That's right. The behavior of the object is dependent solely
             //on who you are pretending to be. Unlike when you override a
@@ -157,7 +157,7 @@ namespace TheKoans
         public void SubclassesCanInvokeParentBehaviorUsingBase()
         {
             var ralph = new BullDog("Ralph");
-            Assert.Equals(FILL_ME_IN, ralph.Bark());
+            Assert.AreEqual(FILL_ME_IN, ralph.Bark());
         }
 
         public class GreatDane : Dog
@@ -173,7 +173,7 @@ namespace TheKoans
         public void YouCanCallBaseEvenFromOtherMethods()
         {
             var george = new BullDog("George");
-            Assert.Equals(FILL_ME_IN, george.Bark());
+            Assert.AreEqual(FILL_ME_IN, george.Bark());
         }
 
     }

--- a/TheKoans/AboutMethods.cs
+++ b/TheKoans/AboutMethods.cs
@@ -39,19 +39,19 @@ namespace TheKoans
         [TestMethod]
         public void ExtensionMethodsShowUpInTheCurrentClass()
         {
-            Assert.Equals(FILL_ME_IN, this.HelloWorld());
+            Assert.AreEqual(FILL_ME_IN, this.HelloWorld());
         }
 
         [TestMethod]
         public void ExtensionMethodsWithParameters()
         {
-            Assert.Equals(FILL_ME_IN, this.SayHello("Cory"));
+            Assert.AreEqual(FILL_ME_IN, this.SayHello("Cory"));
         }
 
         [TestMethod]
         public void ExtensionMethodsWithVariableParameters()
         {
-            Assert.Equals(FILL_ME_IN, this.MethodWithVariableArguments("Cory", "Will", "Corey"));
+            CollectionAssert.AreEqual(FILL_ME_IN, this.MethodWithVariableArguments("Cory", "Will", "Corey"));
         }
 
         //Extension methods can extend any class my referencing 
@@ -61,7 +61,7 @@ namespace TheKoans
         [TestMethod]
         public void ExtendingCoreClasses()
         {
-            Assert.Equals(FILL_ME_IN, "Cory".SayHi());
+            Assert.AreEqual(FILL_ME_IN, "Cory".SayHi());
         }
 
         //Of course, any of the parameter things you can do with 
@@ -75,7 +75,7 @@ namespace TheKoans
         [TestMethod]
         public void LocalMethodsWithVariableParams()
         {
-            Assert.Equals(FILL_ME_IN, this.LocalMethodWithVariableParameters("Cory", "Will", "Corey"));
+            CollectionAssert.AreEqual(FILL_ME_IN, this.LocalMethodWithVariableParameters("Cory", "Will", "Corey"));
         }
 
         //Note how we called the method by saying "this.LocalMethodWithVariableParameters"
@@ -84,7 +84,7 @@ namespace TheKoans
         [TestMethod]
         public void LocalMethodsWithoutExplicitReceiver()
         {
-            Assert.Equals(FILL_ME_IN, LocalMethodWithVariableParameters("Cory", "Will", "Corey"));
+            CollectionAssert.AreEqual(FILL_ME_IN, LocalMethodWithVariableParameters("Cory", "Will", "Corey"));
         }
 
         //But it is required for Extension Methods, since it needs
@@ -110,20 +110,20 @@ namespace TheKoans
         [TestMethod]
         public void CallingStaticMethodsWithoutAnInstance()
         {
-            Assert.Equals(FILL_ME_IN, InnerSecret.Key());
+            Assert.AreEqual(FILL_ME_IN, InnerSecret.Key());
         }
 
         //In fact, you can't call it on an instance variable
         //of the object. So this wouldn't compile:
         //InnerSecret secret = new InnerSecret();
-        //Assert.Equals(FILL_ME_IN, secret.Key());
+        //Assert.AreEqual(FILL_ME_IN, secret.Key());
 
 
         [TestMethod]
         public void CallingPublicMethodsOnAnInstance()
         {
             InnerSecret secret = new InnerSecret();
-            Assert.Equals(FILL_ME_IN, secret.Secret());
+            Assert.AreEqual(FILL_ME_IN, secret.Secret());
         }
 
         //Protected methods can only be called by a subclass
@@ -134,7 +134,7 @@ namespace TheKoans
         public void CallingProtectedMethodsOnAnInstance()
         {
             StateSecret secret = new StateSecret();
-            Assert.Equals(FILL_ME_IN, secret.InformationLeak());
+            Assert.AreEqual(FILL_ME_IN, secret.InformationLeak());
         }
 
         //But, we can't call the private methods of InnerSecret
@@ -151,7 +151,7 @@ namespace TheKoans
             string superSecretMessage = secret.GetType()
                 .GetMethod("SooperSeekrit", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
                 .Invoke(secret, null) as string;
-            Assert.Equals(FILL_ME_IN, superSecretMessage);
+            Assert.AreEqual(FILL_ME_IN, superSecretMessage);
         }
 
         //Up till now we've had explicit return types. It's also
@@ -167,9 +167,9 @@ namespace TheKoans
         [TestMethod]
         public void CallingGenericMethods()
         {
-            Assert.Equals(typeof(FILL_ME_IN), GiveMeBack<int>(1).GetType());
+            Assert.AreEqual(typeof(FILL_ME_IN), GiveMeBack<int>(1).GetType());
 
-            Assert.Equals(FILL_ME_IN, GiveMeBack<string>("Hi!"));
+            Assert.AreEqual(FILL_ME_IN, GiveMeBack<string>("Hi!"));
         }
 
     }

--- a/TheKoans/PathToEnlightenment.orderedtest
+++ b/TheKoans/PathToEnlightenment.orderedtest
@@ -1,11 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<<<<<<< Updated upstream
 <OrderedTest name="pathtoenlightenment" storage="c:\development\csharp-koans\thekoans\pathtoenlightenment.orderedtest" id="2c11c1ff-92ea-4ef2-8d2a-1e1c71da1e52" continueAfterFailure="true" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <Execution id="6c92a212-74cb-4ce0-881b-c07ba3291a3d" />
-=======
-<OrderedTest name="pathtoenlightenment" storage="c:\documents and settings\rjg\my documents\github\csharp-koans\thekoans\pathtoenlightenment.orderedtest" id="2c11c1ff-92ea-4ef2-8d2a-1e1c71da1e52" continueAfterFailure="true" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-  <Execution id="e7458d8b-0e40-4159-863e-4d7939f42fe7" />
->>>>>>> Stashed changes
   <TestLinks>
     <TestLink id="3f939ea7-d919-f759-563e-26664545ac26" name="AssertTruth" storage="bin\debug\thekoans.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <TestLink id="baf91e44-1804-eaaa-8e38-e430f38a5902" name="AssertsShouldHaveMessages" storage="bin\debug\thekoans.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
Fixed a merge conflict in PathToEnlightenment.orderedtest that would
prevent tests from running.
Many changes of Assert.Equals to Assert.AreEqual where Visual Studio
complains.
There are also a few changes of Assert.AreEqual to
CollectionAssert.AreEqual where not part of the example.
